### PR TITLE
Fix copy-paste errors in PKGBUILD

### DIFF
--- a/packaging/archlinux-git/PKGBUILD
+++ b/packaging/archlinux-git/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=songrec-git
 _pkgname=songrec
 pkgver=r61.2e9ce82
-pkgrel=1
+pkgrel=2
 provides=('songrec')
 conflicts=('songrec')
 pkgdesc='An open-source, unofficial Shazam client for Linux, written in Rust.'

--- a/packaging/archlinux-git/PKGBUILD
+++ b/packaging/archlinux-git/PKGBUILD
@@ -28,8 +28,8 @@ package() {
   install -Dm755 "target/release/songrec" "$pkgdir/usr/bin/songrec"
   install -Dm755 "packaging/rootfs/usr/share/applications/com.github.marinm.songrec.desktop" "$pkgdir/usr/share/applications/com.github.marinm.songrec.desktop"
   install -Dm755 "packaging/rootfs/usr/share/icons/hicolor/scalable/apps/com.github.marinm.songrec.svg" \
-                    "$pkgdir/usr/share/applications/icons/hicolor/scalable/apps/com.github.marinm.songrec.svg"
+                    "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.github.marinm.songrec.svg"
   install -Dm755 "packaging/rootfs/usr/share/metainfo/com.github.marinm.songrec.metainfo.xml" \
-                    "$pkgdir/usr/share/applications/metainfo/com.github.marinm.songrec.meteainfo.xml"
+                    "$pkgdir/usr/share/metainfo/com.github.marinm.songrec.meteainfo.xml"
   install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
 }

--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=songrec
 _pkgname=SongRec
 pkgver=0.1.3
-pkgrel=1
+pkgrel=2
 provides=('songrec')
 conflicts=('songrec-git')
 pkgdesc='An open-source, unofficial Shazam client for Linux, written in Rust.'

--- a/packaging/archlinux/PKGBUILD
+++ b/packaging/archlinux/PKGBUILD
@@ -23,8 +23,8 @@ package() {
   install -Dm755 "target/release/songrec" "$pkgdir/usr/bin/songrec"
   install -Dm755 "packaging/rootfs/usr/share/applications/com.github.marinm.songrec.desktop" "$pkgdir/usr/share/applications/com.github.marinm.songrec.desktop"
   install -Dm755 "packaging/rootfs/usr/share/icons/hicolor/scalable/apps/com.github.marinm.songrec.svg" \
-                    "$pkgdir/usr/share/applications/icons/hicolor/scalable/apps/com.github.marinm.songrec.svg"
+                    "$pkgdir/usr/share/icons/hicolor/scalable/apps/com.github.marinm.songrec.svg"
   install -Dm755 "packaging/rootfs/usr/share/metainfo/com.github.marinm.songrec.metainfo.xml" \
-                    "$pkgdir/usr/share/applications/metainfo/com.github.marinm.songrec.meteainfo.xml"
+                    "$pkgdir/usr/share/metainfo/com.github.marinm.songrec.meteainfo.xml"
   install -Dm644 "LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }


### PR DESCRIPTION
The `icons` and `metainfo` directories live in `/usr/share` alongside `applications`, not inside `/usr/share/applications`.