### PR TITLE
Added track key to csv output

### DIFF
--- a/src/gui/csv_song_history.rs
+++ b/src/gui/csv_song_history.rs
@@ -16,7 +16,8 @@ use gtk::prelude::*;
 pub struct SongHistoryRecord {
     pub song_name: String,
     pub album: String,
-    pub recognition_date: String
+    pub recognition_date: String,
+    pub track_key: String
 }
 
 pub struct SongHistoryInterface {

--- a/src/gui/csv_song_history.rs
+++ b/src/gui/csv_song_history.rs
@@ -17,6 +17,7 @@ pub struct SongHistoryRecord {
     pub song_name: String,
     pub album: String,
     pub recognition_date: String,
+    #[serde(default)]
     pub track_key: String
 }
 
@@ -58,7 +59,9 @@ impl SongHistoryInterface {
     /// history is stored here.
     
     fn load(self: &mut Self) -> Result<(), Box<dyn Error>> {
-        match csv::Reader::from_path(&self.csv_path) {
+        match csv::ReaderBuilder::new()
+        .flexible(true)
+        .from_path(&self.csv_path) {
             Ok(mut reader) => {
                     
                 for result in reader.deserialize() {

--- a/src/gui/csv_song_history.rs
+++ b/src/gui/csv_song_history.rs
@@ -17,8 +17,14 @@ pub struct SongHistoryRecord {
     pub song_name: String,
     pub album: String,
     pub recognition_date: String,
+    
+    // The following fields have been added in version 0.2.2
     #[serde(default)]
-    pub track_key: String
+    pub track_key: String,
+    #[serde(default)]
+    pub release_year: String,
+    #[serde(default)]
+    pub genre: String
 }
 
 pub struct SongHistoryInterface {

--- a/src/gui/http_thread.rs
+++ b/src/gui/http_thread.rs
@@ -12,6 +12,7 @@ fn try_recognize_song(signature: DecodedSignature) -> Result<SongRecognizedMessa
     let json_object = recognize_song_from_signature(&signature)?;
     
     let mut album_name: Option<String> = None;
+    let mut release_year: Option<String> = None;
     
     // Sometimes the idea of trying to write functional poetry hurts
     
@@ -25,7 +26,11 @@ fn try_recognize_song(signature: DecodedSignature) -> Result<SongRecognizedMessa
                                 if title == "Album" {
                                     if let Value::String(text) = &metadatum["text"] {
                                         album_name = Some(text.to_string());
-                                        break;
+                                    }
+                                }
+                                else if title == "Released" {
+                                    if let Value::String(text) = &metadatum["text"] {
+                                        release_year = Some(text.to_string());
                                     }
                                 }
                             }
@@ -56,6 +61,11 @@ fn try_recognize_song(signature: DecodedSignature) -> Result<SongRecognizedMessa
             Value::String(string) => string.to_string(),
             _ => { return Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, gettext("No match for this song").as_str()))) }
         },
+        release_year: release_year,
+        genre: match &json_object["track"]["genres"]["primary"] {
+            Value::String(string) => Some(string.to_string()),
+            _ => None
+        }
     })
 }
 

--- a/src/gui/http_thread.rs
+++ b/src/gui/http_thread.rs
@@ -51,7 +51,11 @@ fn try_recognize_song(signature: DecodedSignature) -> Result<SongRecognizedMessa
             Value::String(string) => Some(obtain_raw_cover_image(string)?),
             _ => None
         },
-        signature: Box::new(signature)
+        signature: Box::new(signature),
+        track_key: match &json_object["track"]["key"] {
+            Value::String(string) => string.to_string(),
+            _ => { return Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, gettext("No match for this song").as_str()))) }
+        },
     })
 }
 

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -544,7 +544,9 @@ pub fn gui_main(recording: bool, input_file: Option<&str>) -> Result<(), Box<dyn
                             song_name: song_name.as_ref().unwrap().to_string(),
                             album: message.album_name.as_ref().unwrap_or(&"".to_string()).to_string(),
                             recognition_date: Local::now().format("%c").to_string(),
-                            track_key: message.track_key
+                            track_key: message.track_key,
+                            release_year: message.release_year.as_ref().unwrap_or(&"".to_string()).to_string(),
+                            genre: message.genre.as_ref().unwrap_or(&"".to_string()).to_string(),
                         });
 
                         recognized_song_name.set_markup(&format!("<b>{}</b>", glib::markup_escape_text(song_name.as_ref().unwrap())));

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -543,7 +543,8 @@ pub fn gui_main(recording: bool, input_file: Option<&str>) -> Result<(), Box<dyn
                         song_history_interface.add_column_and_save(SongHistoryRecord {
                             song_name: song_name.as_ref().unwrap().to_string(),
                             album: message.album_name.as_ref().unwrap_or(&"".to_string()).to_string(),
-                            recognition_date: Local::now().format("%c").to_string()
+                            recognition_date: Local::now().format("%c").to_string(),
+                            track_key: message.track_key
                         });
 
                         recognized_song_name.set_markup(&format!("<b>{}</b>", glib::markup_escape_text(song_name.as_ref().unwrap())));

--- a/src/gui/thread_messages.rs
+++ b/src/gui/thread_messages.rs
@@ -8,12 +8,20 @@ pub struct SongRecognizedMessage {
     pub song_name: String,
     pub cover_image: Option<Vec<u8>>,
     pub signature: Box<DecodedSignature>,
-    pub track_key: String
+    
+    // Used only in the CSV export for now:
+    pub track_key: String,
+    pub release_year: Option<String>,
+    pub genre: Option<String>
 }
 
 pub enum GUIMessage {
     ErrorMessage(String),
-    DevicesList(Box<Vec<String>>), // A list of audio devices, received from the microphone thread because CPAL can't be called from the same thread as the GUI under Windows
+    // A list of audio devices, received from the microphone thread
+    // because CPAL can't be called from the same thread as the GUI
+    // under Windows
+    DevicesList(Box<Vec<String>>),
+    
     NetworkStatus(bool), // Is the network reachable?
     WipeSongHistory,
     MicrophoneRecording,

--- a/src/gui/thread_messages.rs
+++ b/src/gui/thread_messages.rs
@@ -7,7 +7,8 @@ pub struct SongRecognizedMessage {
     pub album_name: Option<String>,
     pub song_name: String,
     pub cover_image: Option<Vec<u8>>,
-    pub signature: Box<DecodedSignature>
+    pub signature: Box<DecodedSignature>,
+    pub track_key: String
 }
 
 pub enum GUIMessage {


### PR DESCRIPTION
I've been using the continuous CSV output for a while and it's been working great! However, I wanted to be able to get more info about tracks by using the key and calling the Shazam site. So I added a new field to capture the 'key' field value from the original JSON response and I added it to the CSV output as the last field called 'track_key'

**New CSV Output Example:**
song_name,album,recognition_date,track_key
Flowdan Feat. Irah - Level,Level (feat. Irah) - EP,Thu Oct 14 22:50:12 2021,**464064459**

Then you can use the track key value at the end to call the following URL and get the JSON:
https://www.shazam.com/discovery/v5/en-US/US/web/-/track/464064459?shazamapiversion=v3

And also easily get the number of Shazams:
https://www.shazam.com/services/count/v2/web/track/464064459

**Note:** If you have an existing song_history.csv file, you may need to delete it before it will output the new structure.