### PR TITLE
Only block "upmix" and "downmix" audio devices on Linux.

### DIFF
--- a/src/audio_controllers/cpal.rs
+++ b/src/audio_controllers/cpal.rs
@@ -17,6 +17,7 @@ impl AudioBackend for CpalBackend {
             // source on an ALSA-based configuration may
             // crash our underlying sound library.
             
+            #[cfg(target_os = "linux")]
             if device_name.contains("upmix") || device_name.contains("downmix") {
                 continue;
             }


### PR DESCRIPTION
I restricted the "upmix"/"downmix" audio device name check to Linux platforms via a cfg attribute, as this issue is one that should only affect Linux. Should, for whatever reason, the user have an audio device containing "upmix" or "downmix" on Windows, they will now be unaffected by this Linux-specific workaround.

Testing whether or not the user is using ALSA is still yet to be implemented, but this change means that _if_ that ever becomes a prominent issue, the workaround can be removed without affecting non-Linux users.

It may be a bit pedantic, but I think restricting workarounds to their intended edge-case is generally a good idea.