### PR TITLE
fix: rectify window icon under Wayland

### DIFF
--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -41,6 +41,8 @@ pub fn gui_main(recording: bool, input_file: Option<&str>, enable_mpris_cli: boo
         gio::ApplicationFlags::HANDLES_OPEN)
         .expect(&gettext("Application::new failed"));
 
+    glib::set_prgname(Some("com.github.marinm.songrec"));
+
     application.connect_startup(move |application| {
         
         let interface_src = include_str!("interface.glade");


### PR DESCRIPTION
Set the desktop filename to fix window icon under Wayland.