### PR TITLE
fix main loop hang cli subcommmands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -332,9 +332,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .unwrap()
                 .clone();
 
-            let main_context = glib::MainContext::new();
-            let main_loop = glib::MainLoop::new(Some(&main_context), false);
-            main_context.spawn_local(async move {
+            let main_loop = glib::MainLoop::new(None, false);
+            let main_loop_inner = main_loop.clone();
+            glib::spawn_future_local(async move {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(
@@ -348,6 +348,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     )
                     .unwrap()
                 );
+                main_loop_inner.quit();
             });
             main_loop.run();
         }
@@ -376,9 +377,9 @@ fn main() -> Result<(), Box<dyn Error>> {
             let session = soup::Session::new();
             session.set_timeout(20);
 
-            let main_context = glib::MainContext::new();
-            let main_loop = glib::MainLoop::new(Some(&main_context), false);
-            main_context.spawn_local(async move {
+            let main_loop = glib::MainLoop::new(None, false);
+            let main_loop_inner = main_loop.clone();
+            glib::spawn_future_local(async move {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(
@@ -391,6 +392,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     )
                     .unwrap()
                 );
+                main_loop_inner.quit();
             });
             main_loop.run();
         }


### PR DESCRIPTION
Found a problem with some legacy CLI subcommands, the `audio-file-to-recognized-song` and `fingerprint-to-recognized-song` hang indefinitely, never exiting.
These subcommands created a new `glib::MainContext` but never set it as the thread default. The future scheduled via `main_context.spawn_local()` was never polled and this (I think) made the Shazam API request never execute and `main_loop.run()` blocked forever doing nothing.
And after fixing this, The async block had no `main_loop.quit()` call, so after printing the result the main loop would keep running.

Tested using `cargo run -- audio-file-to-recognized-song python-version/tests/stupeflip.wav`