### PR TITLE
Restore GTK4 audio level indicator behavior for microphone/loopback capture

### DIFF
--- a/src/gui/interface.ui
+++ b/src/gui/interface.ui
@@ -220,7 +220,7 @@
                                         <property name="margin-end">15</property>
                                         <property name="margin-start">15</property>
                                         <property name="margin-top">15</property>
-                                        <property name="spacing">6</property>
+                                        <property name="spacing">15</property>
                                         <child>
                                           <object class="GtkLabel" id="volume_label">
                                             <property name="label" translatable="yes">Volume:</property>
@@ -228,6 +228,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkProgressBar" id="volume_gauge">
+                                            <property name="hexpand">True</property>
                                             <property name="valign">center</property>
                                           </object>
                                         </child>

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -1062,15 +1062,17 @@ impl App {
                                 );
 
                                 microphone_switch.set_visible(true);
-                                volume_row
-                                    .set_visible(microphone_switch.is_active() || loopback_switch.is_active());
+                                volume_row.set_visible(
+                                    microphone_switch.is_active() || loopback_switch.is_active(),
+                                );
 
                                 // Will trigger the "input_device_switched" callback
                             }
                         }
                         MicrophoneRecording => {
-                            volume_row
-                                .set_visible(microphone_switch.is_active() || loopback_switch.is_active());
+                            volume_row.set_visible(
+                                microphone_switch.is_active() || loopback_switch.is_active(),
+                            );
                             volume_gauge.set_fraction(0.0);
                         }
 

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -435,10 +435,13 @@ impl App {
             let device_section: adw::PreferencesGroup =
                 builder.object("input_device_section").unwrap();
             let g_list_store: gio::ListStore = builder.object("audio_inputs_model").unwrap();
+            let volume_row: adw::PreferencesRow = builder.object("volume_row").unwrap();
+            let volume_gauge: gtk::ProgressBar = builder.object("volume_gauge").unwrap();
 
             if loopback_switch.is_active() {
                 microphone_switch.set_active(false);
                 device_section.set_visible(true);
+                volume_row.set_visible(true);
 
                 let adw_combo_row: adw::ComboRow = builder.object("audio_inputs").unwrap();
 
@@ -473,6 +476,8 @@ impl App {
                 }
             } else if !microphone_switch.is_active() && !loopback_switch.is_active() {
                 device_section.set_visible(false);
+                volume_row.set_visible(false);
+                volume_gauge.set_fraction(0.0);
                 microphone_tx
                     .try_send(MicrophoneMessage::MicrophoneRecordStop)
                     .unwrap();
@@ -490,10 +495,13 @@ impl App {
             let device_section: adw::PreferencesGroup =
                 builder.object("input_device_section").unwrap();
             let g_list_store: gio::ListStore = builder.object("audio_inputs_model").unwrap();
+            let volume_row: adw::PreferencesRow = builder.object("volume_row").unwrap();
+            let volume_gauge: gtk::ProgressBar = builder.object("volume_gauge").unwrap();
 
             if microphone_switch.is_active() {
                 loopback_switch.set_active(false);
                 device_section.set_visible(true);
+                volume_row.set_visible(true);
 
                 let adw_combo_row: adw::ComboRow = builder.object("audio_inputs").unwrap();
 
@@ -528,6 +536,8 @@ impl App {
                 }
             } else if !microphone_switch.is_active() && !loopback_switch.is_active() {
                 device_section.set_visible(false);
+                volume_row.set_visible(false);
+                volume_gauge.set_fraction(0.0);
                 microphone_tx
                     .try_send(MicrophoneMessage::MicrophoneRecordStop)
                     .unwrap();
@@ -543,6 +553,7 @@ impl App {
         builder_scope.add_callback("input_device_switched", move |values| {
             let microphone_switch: adw::SwitchRow = builder.object("microphone_switch").unwrap();
             let loopback_switch: adw::SwitchRow = builder.object("loopback_switch").unwrap();
+            let volume_gauge: gtk::ProgressBar = builder.object("volume_gauge").unwrap();
 
             let combo_row = values[0].get::<adw::ComboRow>().unwrap();
 
@@ -575,6 +586,7 @@ impl App {
                 // command line flags of the application)
 
                 if microphone_switch.is_active() || loopback_switch.is_active() {
+                    volume_gauge.set_fraction(0.0);
                     microphone_tx
                         .try_send(MicrophoneMessage::MicrophoneRecordStop)
                         .unwrap();
@@ -1050,15 +1062,21 @@ impl App {
                                 );
 
                                 microphone_switch.set_visible(true);
-                                volume_row.set_visible(true);
+                                volume_row
+                                    .set_visible(microphone_switch.is_active() || loopback_switch.is_active());
 
                                 // Will trigger the "input_device_switched" callback
                             }
                         }
-                        MicrophoneRecording => {}
+                        MicrophoneRecording => {
+                            volume_row
+                                .set_visible(microphone_switch.is_active() || loopback_switch.is_active());
+                            volume_gauge.set_fraction(0.0);
+                        }
 
                         MicrophoneVolumePercent(percent) => {
-                            volume_gauge.set_fraction((percent / 100.0) as f64);
+                            let clamped_percent = percent.clamp(0.0, 100.0);
+                            volume_gauge.set_fraction((clamped_percent / 100.0) as f64);
                         }
 
                         WipeSongHistory => {


### PR DESCRIPTION
Restores the GTK4 volume indicator so users can clearly see when live input is being tracked.  
The meter now appears during active mic/loopback capture, resets on stop or device switch, and clamps level updates for stable rendering.  
Also adjusts the volume row layout to make the bar more visible, while keeping current UI wording (Volume:).