### PR TITLE
Fix all but two clippy warnings

### DIFF
--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -205,28 +205,12 @@ pub fn cli_main(parameters: CLIParameters) -> Result<(), Box<dyn Error>> {
                                 csv_writer
                                     .serialize(SongHistoryRecord {
                                         song_name,
-                                        album: Some(
-                                            message
-                                                .album_name
-                                                .as_ref()
-                                                .unwrap_or(&"".to_string())
-                                                .to_string(),
-                                        ),
+                                        album: Some(message.album_name.unwrap_or_default()),
                                         track_key: Some(message.track_key),
                                         release_year: Some(
-                                            message
-                                                .release_year
-                                                .as_ref()
-                                                .unwrap_or(&"".to_string())
-                                                .to_string(),
+                                            message.release_year.unwrap_or_default(),
                                         ),
-                                        genre: Some(
-                                            message
-                                                .genre
-                                                .as_ref()
-                                                .unwrap_or(&"".to_string())
-                                                .to_string(),
-                                        ),
+                                        genre: Some(message.genre.unwrap_or_default()),
                                         recognition_date: Local::now().format("%c").to_string(),
                                     })
                                     .unwrap();

--- a/src/cli_main.rs
+++ b/src/cli_main.rs
@@ -175,18 +175,15 @@ pub fn cli_main(parameters: CLIParameters) -> Result<(), Box<dyn Error>> {
                     }
                 }
                 GUIMessage::ErrorMessage(string) => {
-                    if !(string == gettext("No match for this song") && !input_file_name.is_some())
-                    {
+                    if string != gettext("No match for this song") || input_file_name.is_some() {
                         error!("{} {}", gettext("Error:"), string);
                     }
                     if input_file_name.is_some() {
                         break;
                     }
                 }
-                GUIMessage::MicrophoneRecording => {
-                    if !do_recognize_once {
-                        info!("{}", gettext("Recording started!"));
-                    }
+                GUIMessage::MicrophoneRecording if !do_recognize_once => {
+                    info!("{}", gettext("Recording started!"));
                 }
                 GUIMessage::SongRecognized(message) => {
                     let track_key = Some(message.track_key.clone());
@@ -207,7 +204,7 @@ pub fn cli_main(parameters: CLIParameters) -> Result<(), Box<dyn Error>> {
                             CLIOutputType::CSV => {
                                 csv_writer
                                     .serialize(SongHistoryRecord {
-                                        song_name: song_name,
+                                        song_name,
                                         album: Some(
                                             message
                                                 .album_name

--- a/src/core/audio_controllers/audio_backend.rs
+++ b/src/core/audio_controllers/audio_backend.rs
@@ -12,9 +12,9 @@ pub fn get_any_backend() -> Box<dyn AudioBackend> {
 
     #[cfg(all(target_os = "linux", feature = "pulse"))]
     if let Some(backend) = PulseBackend::try_init() {
-        return Box::new(backend);
+        Box::new(backend)
     } else {
-        return Box::new(CpalBackend {});
+        Box::new(CpalBackend {})
     }
 }
 

--- a/src/core/audio_controllers/pulseaudio.rs
+++ b/src/core/audio_controllers/pulseaudio.rs
@@ -71,16 +71,16 @@ impl AudioBackend for PulseBackend {
                     for dev in devices {
                         if let Some(desc) = &dev.description {
                             if let Some(name) = &dev.name {
-                                if &dev.name == &info.default_source_name {
+                                if dev.name == info.default_source_name {
                                     device_names.insert(
                                         0,
                                         DeviceListItem {
                                             inner_name: name.to_string(),
                                             display_name: desc.to_string(),
-                                            is_monitor: dev.monitor != None,
+                                            is_monitor: dev.monitor.is_some(),
                                         },
                                     );
-                                } else if dev.monitor != None {
+                                } else if dev.monitor.is_some() {
                                     monitor_device_names.push(DeviceListItem {
                                         inner_name: name.to_string(),
                                         display_name: desc.to_string(),

--- a/src/core/fingerprinting/hanning.rs
+++ b/src/core/fingerprinting/hanning.rs
@@ -1,6 +1,5 @@
 /// Multipliers for applying hanning window over 2048 entries, with
 /// leading and trailing zeroes omitted.
-
 pub const HANNING_WINDOW_2048_MULTIPLIERS: [f32; 2048] = [
     0.0000023508,
     0.0000094032,

--- a/src/core/fingerprinting/signature_format.rs
+++ b/src/core/fingerprinting/signature_format.rs
@@ -2,7 +2,6 @@ use base64::Engine;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
 use gettextrs::gettext;
-use std::cmp::Ordering;
 use std::error::Error;
 use std::io::{Cursor, Seek, SeekFrom, Write};
 
@@ -14,24 +13,12 @@ pub struct FrequencyPeak {
     pub corrected_peak_frequency_bin: u16,
 }
 
-#[derive(Hash, Eq, PartialEq, Debug, Clone, Copy)]
+#[derive(Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy)]
 pub enum FrequencyBand {
     _250_520 = 0,
     _520_1450 = 1,
     _1450_3500 = 2,
     _3500_5500 = 3,
-}
-
-impl Ord for FrequencyBand {
-    fn cmp(&self, other: &Self) -> Ordering {
-        (*self as i32).cmp(&(*other as i32))
-    }
-}
-
-impl PartialOrd for FrequencyBand {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some((*self as i32).cmp(&(*other as i32)))
-    }
 }
 
 struct RawSignatureHeader {

--- a/src/core/fingerprinting/signature_format.rs
+++ b/src/core/fingerprinting/signature_format.rs
@@ -173,18 +173,18 @@ impl DecodedSignature {
         // Return the decoded object
 
         Ok(DecodedSignature {
-            sample_rate_hz: sample_rate_hz,
-            number_samples: number_samples,
-            frequency_band_to_sound_peaks: frequency_band_to_sound_peaks,
+            sample_rate_hz,
+            number_samples,
+            frequency_band_to_sound_peaks,
         })
     }
 
     pub fn decode_from_uri(uri: &str) -> Result<Self, Box<dyn Error>> {
         assert!(uri.starts_with(DATA_URI_PREFIX));
 
-        Ok(DecodedSignature::decode_from_binary(
+        DecodedSignature::decode_from_binary(
             &base64::prelude::BASE64_STANDARD.decode(&uri[DATA_URI_PREFIX.len()..])?,
-        )?)
+        )
     }
 
     pub fn encode_to_binary(&self) -> Result<Vec<u8>, Box<dyn Error>> {
@@ -229,7 +229,7 @@ impl DecodedSignature {
         for (frequency_band, frequency_peaks) in
             self.frequency_band_to_sound_peaks.iter().enumerate()
         {
-            if frequency_peaks.len() == 0 {
+            if frequency_peaks.is_empty() {
                 continue;
             }
             let mut peaks_cursor = Cursor::new(vec![]);

--- a/src/core/fingerprinting/user_agent.rs
+++ b/src/core/fingerprinting/user_agent.rs
@@ -1,6 +1,6 @@
 // From https://github.com/SaswatPadhi/FlashProfileDemo/blob/c1e3f05d09f6443568a606dc0a439d6ebb057ae1/tests/hetero/user_agents.json
 
-pub const USER_AGENTS: [&'static str; 100] = [
+pub const USER_AGENTS: [&str; 100] = [
     "Dalvik/2.1.0 (Linux; U; Android 5.0.2; VS980 4G Build/LRX22G)",
     "Dalvik/1.6.0 (Linux; U; Android 4.4.2; SM-T210 Build/KOT49H)",
     "Dalvik/2.1.0 (Linux; U; Android 5.1.1; SM-P905V Build/LMY47X)",

--- a/src/core/http_task.rs
+++ b/src/core/http_task.rs
@@ -51,18 +51,16 @@ async fn try_recognize_song(
         artist_name: match &json_object["track"]["subtitle"] {
             Value::String(string) => string.to_string(),
             _ => {
-                return Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(Box::new(std::io::Error::other(
                     gettext("No match for this song").as_str(),
                 )))
             }
         },
-        album_name: album_name,
+        album_name,
         song_name: match &json_object["track"]["title"] {
             Value::String(string) => string.to_string(),
             _ => {
-                return Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(Box::new(std::io::Error::other(
                     gettext("No match for this song").as_str(),
                 )))
             }
@@ -74,13 +72,12 @@ async fn try_recognize_song(
         track_key: match &json_object["track"]["key"] {
             Value::String(string) => string.to_string(),
             _ => {
-                return Err(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                return Err(Box::new(std::io::Error::other(
                     gettext("No match for this song").as_str(),
                 )))
             }
         },
-        release_year: release_year,
+        release_year,
         genre: match &json_object["track"]["genres"]["primary"] {
             Value::String(string) => Some(string.to_string()),
             _ => None,
@@ -90,8 +87,7 @@ async fn try_recognize_song(
             .replace_all(
                 &Regex::new("([,:])\n *")
                     .unwrap()
-                    .replace_all(&to_string_pretty(&json_object).unwrap(), "$1 ")
-                    .into_owned(),
+                    .replace_all(&to_string_pretty(&json_object).unwrap(), "$1 "),
                 "",
             )
             .into_owned(),

--- a/src/core/microphone_thread.rs
+++ b/src/core/microphone_thread.rs
@@ -49,7 +49,7 @@ pub fn microphone_thread(
     let device_names: Vec<DeviceListItem> = backend.list_devices(&host);
 
     gui_tx
-        .try_send(GUIMessage::DevicesList(Box::new(device_names)))
+        .try_send(GUIMessage::DevicesList(device_names))
         .unwrap();
 
     // Process ingress inter-thread messages (stopping or starting
@@ -220,7 +220,7 @@ pub fn microphone_thread(
                 let device_names: Vec<DeviceListItem> = backend.list_devices(&host);
 
                 gui_tx
-                    .try_send(GUIMessage::DevicesList(Box::new(device_names)))
+                    .try_send(GUIMessage::DevicesList(device_names))
                     .unwrap();
             }
 
@@ -296,9 +296,9 @@ fn write_data(
     {
         if !twelve_seconds_buffer.iter().all(|x| *x == 0.0) {
             processing_tx
-                .try_send(ProcessingMessage::ProcessAudioSamples(Box::new(
+                .try_send(ProcessingMessage::ProcessAudioSamples(
                     twelve_seconds_buffer.to_vec(),
-                )))
+                ))
                 .unwrap();
 
             *processing_already_ongoing_borrow = true;

--- a/src/core/microphone_thread.rs
+++ b/src/core/microphone_thread.rs
@@ -292,7 +292,7 @@ fn write_data(
     let mut processing_already_ongoing_borrow = processing_already_ongoing.lock().unwrap();
 
     if *number_unprocessed_samples >= 16000 * request_interval_secs
-        && *processing_already_ongoing_borrow == false
+        && !*processing_already_ongoing_borrow
     {
         if !twelve_seconds_buffer.iter().all(|x| *x == 0.0) {
             processing_tx

--- a/src/core/preferences.rs
+++ b/src/core/preferences.rs
@@ -81,13 +81,13 @@ pub struct PreferencesInterface {
 impl PreferencesInterface {
     pub fn new() -> Self {
         match PreferencesInterface::load() {
-            Ok(preferences_interface) => return preferences_interface,
+            Ok(preferences_interface) => preferences_interface,
             Err(e) => {
                 error!("{} {}", gettext("When parsing the preferences file:"), e);
-                return PreferencesInterface {
+                PreferencesInterface {
                     preferences_file_path: obtain_preferences_file_path().ok(),
                     preferences: Preferences::default(),
-                };
+                }
             }
         }
     }
@@ -108,11 +108,11 @@ impl PreferencesInterface {
         );
         Ok(PreferencesInterface {
             preferences_file_path: Some(preferences_file_path),
-            preferences: preferences,
+            preferences,
         })
     }
 
-    pub fn update(self: &mut Self, update_preferences: Preferences) {
+    pub fn update(&mut self, update_preferences: Preferences) {
         let current_preferences = self.preferences.clone();
         self.preferences = Preferences {
             enable_notifications: update_preferences
@@ -156,7 +156,7 @@ impl PreferencesInterface {
         }
     }
 
-    fn write(self: &mut Self) -> Result<(), Box<dyn Error>> {
+    fn write(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(preferences_file_path) = &self.preferences_file_path {
             let mut file = OpenOptions::new()
                 .write(true)

--- a/src/core/preferences.rs
+++ b/src/core/preferences.rs
@@ -3,8 +3,6 @@ use log::{debug, error};
 use serde::Deserialize;
 use serde::Serialize;
 use std::error::Error;
-use std::fs::OpenOptions;
-use std::io::{Read, Write};
 
 use crate::utils::filesystem_operations::obtain_preferences_file_path;
 
@@ -94,13 +92,7 @@ impl PreferencesInterface {
 
     fn load() -> Result<PreferencesInterface, Box<dyn Error>> {
         let preferences_file_path: String = obtain_preferences_file_path()?;
-        let mut file = OpenOptions::new()
-            .write(true)
-            .read(true)
-            .create(true)
-            .open(&preferences_file_path)?;
-        let mut contents: String = String::new();
-        file.read_to_string(&mut contents)?;
+        let contents = std::fs::read_to_string(&preferences_file_path).unwrap_or_default();
         let preferences: Preferences = toml::from_str(&contents)?;
         debug!(
             "Loaded preferences from {}: {:?}",
@@ -158,14 +150,8 @@ impl PreferencesInterface {
 
     fn write(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(preferences_file_path) = &self.preferences_file_path {
-            let mut file = OpenOptions::new()
-                .write(true)
-                .truncate(true)
-                .create(true)
-                .open(preferences_file_path.as_str())?;
             let contents: String = toml::to_string(&self.preferences)?;
-            file.write_all(contents.as_bytes())?;
-            file.flush()?;
+            std::fs::write(preferences_file_path, contents)?;
         }
         Ok(())
     }

--- a/src/core/thread_messages.rs
+++ b/src/core/thread_messages.rs
@@ -6,7 +6,7 @@ use std::thread;
 
 /// This module contains code used from message-based communication between threads.
 
-pub fn spawn_big_thread<F, T>(argument: F) -> ()
+pub fn spawn_big_thread<F, T>(argument: F)
 where
     F: std::ops::FnOnce() -> T,
     F: std::marker::Send + 'static,

--- a/src/core/thread_messages.rs
+++ b/src/core/thread_messages.rs
@@ -1,10 +1,10 @@
+//! This module contains code used from message-based communication between threads.
+
 use crate::core::fingerprinting::signature_format::DecodedSignature;
 #[cfg(feature = "gui")]
 use crate::core::preferences::Preferences;
 
 use std::thread;
-
-/// This module contains code used from message-based communication between threads.
 
 pub fn spawn_big_thread<F, T>(argument: F)
 where
@@ -50,7 +50,7 @@ pub enum GUIMessage {
     // A list of audio devices, received from the microphone thread
     // because CPAL can't be called from the same thread as the GUI
     // under Windows
-    DevicesList(Box<Vec<DeviceListItem>>),
+    DevicesList(Vec<DeviceListItem>),
     #[cfg(feature = "gui")]
     UpdatePreference(Preferences),
     NetworkStatus(bool),  // Is the network reachable?
@@ -74,7 +74,7 @@ pub enum MicrophoneMessage {
 
 pub enum ProcessingMessage {
     ProcessAudioFile(String),
-    ProcessAudioSamples(Box<Vec<f32>>), // Prefer to use heap across threads to avoid stack overflow
+    ProcessAudioSamples(Vec<f32>), // Prefer to use heap across threads to avoid stack overflow
 }
 
 pub enum HTTPMessage {

--- a/src/gui/history_entry/mod.rs
+++ b/src/gui/history_entry/mod.rs
@@ -49,46 +49,10 @@ impl HistoryEntry {
     pub fn get_song(&self) -> Song {
         Song {
             song_name: self.song_name(),
-            album: match self.album() {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-            track_key: match self.track_key() {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-            release_year: match self.release_year() {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-            genre: match self.genre() {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
+            album: self.album().filter(|val| !val.is_empty()),
+            track_key: self.track_key().filter(|val| !val.is_empty()),
+            release_year: self.release_year().filter(|val| !val.is_empty()),
+            genre: self.genre().filter(|val| !val.is_empty()),
         }
     }
 }

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -1006,14 +1006,13 @@ impl App {
                             let mut initial_device_index: u32 = 0;
                             let mut initial_device: Option<ListedDevice> = None;
                             let mut found_monitor_device = false;
-                            let mut current_index: u32 = 0;
 
                             // Fill in the list of available devices, and
                             // set back the old device if it was recorded
 
                             g_list_store.remove_all();
 
-                            for device in devices.iter() {
+                            for (current_index, device) in devices.iter().enumerate() {
                                 // device: thread_messages::DeviceListItem
                                 let listed_device = ListedDevice::new(
                                     device.display_name.clone(),
@@ -1022,19 +1021,16 @@ impl App {
                                 );
                                 g_list_store.append(&listed_device);
 
-                                if old_device_name == Some(device.inner_name.to_string()) {
-                                    initial_device_index = current_index;
-                                    initial_device = Some(listed_device);
-                                } else if old_device_name.is_none()
-                                    && device.is_monitor
-                                    && !found_monitor_device
+                                if (old_device_name == Some(device.inner_name.to_string()))
+                                    || (old_device_name.is_none()
+                                        && device.is_monitor
+                                        && !found_monitor_device)
                                 {
-                                    initial_device_index = current_index;
+                                    initial_device_index = current_index as u32;
                                     initial_device = Some(listed_device);
                                 } else if current_index == 0 {
                                     initial_device = Some(listed_device);
                                 }
-                                current_index += 1;
 
                                 if device.is_monitor {
                                     found_monitor_device = true;

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -409,7 +409,7 @@ impl App {
 
             let text = match prop_name.as_str() {
                 "song_name" => entry.song_name(),
-                "album" => entry.album().unwrap_or(String::new()),
+                "album" => entry.album().unwrap_or_default(),
                 "recognition_date" => entry.recognition_date(),
                 _ => unreachable!(),
             };
@@ -958,28 +958,10 @@ impl App {
 
                                 let new_entry = SongHistoryRecord {
                                     song_name,
-                                    album: Some(
-                                        message
-                                            .album_name
-                                            .as_ref()
-                                            .unwrap_or(&"".to_string())
-                                            .to_string(),
-                                    ),
+                                    album: Some(message.album_name.unwrap_or_default()),
                                     track_key: Some(message.track_key),
-                                    release_year: Some(
-                                        message
-                                            .release_year
-                                            .as_ref()
-                                            .unwrap_or(&"".to_string())
-                                            .to_string(),
-                                    ),
-                                    genre: Some(
-                                        message
-                                            .genre
-                                            .as_ref()
-                                            .unwrap_or(&"".to_string())
-                                            .to_string(),
-                                    ),
+                                    release_year: Some(message.release_year.unwrap_or_default()),
+                                    genre: Some(message.genre.unwrap_or_default()),
                                     recognition_date: Local::now().format("%c").to_string(),
                                 };
 

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -198,7 +198,7 @@ impl App {
         let processing_tx = self.processing_tx.clone();
 
         application.connect_open(move |_application, files, _hint| {
-            if files.len() >= 1 {
+            if !files.is_empty() {
                 if let Some(file_path) = files[0].path() {
                     let file_path_string = file_path.into_os_string().into_string().unwrap();
 
@@ -241,7 +241,7 @@ impl App {
             == Some(true)
         {
             let notification = gio::Notification::new(&gettext("Application error"));
-            notification.set_body(Some(&label));
+            notification.set_body(Some(label));
             notification.set_category(Some("network.error"));
             application.send_notification(Some("application-error"), &notification);
         }
@@ -262,7 +262,7 @@ impl App {
                 == Some(true)
         {
             let notification = gio::Notification::new(&gettext("Network error"));
-            notification.set_body(Some(&label));
+            notification.set_body(Some(label));
             notification.set_category(Some("network.error"));
             application.send_notification(Some("network-error"), &notification);
         }
@@ -737,7 +737,7 @@ impl App {
                     const MAX_LOG_SIZE: usize = 2 * 1024 * 1024; // 2 MB
 
                     {
-                        let buffer_ptr: &mut String = &mut *ctx_buffered_log.borrow_mut();
+                        let buffer_ptr: &mut String = &mut ctx_buffered_log.borrow_mut();
                         buffer_ptr.push_str(&log_string);
                         if buffer_ptr.len() > MAX_LOG_SIZE {
                             let to_cut: String = buffer_ptr
@@ -751,19 +751,19 @@ impl App {
                     if let MicrophoneVolumePercent(_) = gui_message {
                         trace!("Received GUI message: {:?}", gui_message);
                     } else if let SongRecognized(ref msg) = gui_message {
-                        debug!("Received GUI message: SongRecognized({})", json!({
-                            "artist_name": msg.artist_name.clone(),
-                            "album_name": msg.album_name.clone(),
-                            "song_name": msg.song_name.clone(),
-                            "cover_image": match &msg.cover_image {
-                                Some(data) => Some::<String>(format!("{:02x?}...", &data[..16]).into()),
-                                None => None
-                            },
-                            "track_key": msg.track_key.clone(),
-                            "release_year": msg.release_year.clone(),
-                            "genre": msg.genre.clone(),
-                            "shazam_json": msg.shazam_json.clone()
-                        }).to_string());
+                        debug!(
+                            "Received GUI message: SongRecognized({})",
+                            json!({
+                                "artist_name": msg.artist_name.clone(),
+                                "album_name": msg.album_name.clone(),
+                                "song_name": msg.song_name.clone(),
+                                "cover_image": msg.cover_image.as_ref().map(|data| format!("{:02x?}...", &data[..16])),
+                                "track_key": msg.track_key.clone(),
+                                "release_year": msg.release_year.clone(),
+                                "genre": msg.genre.clone(),
+                                "shazam_json": msg.shazam_json.clone()
+                            })
+                        );
                     } else {
                         debug!("Received GUI message: {:?}", gui_message);
                     }
@@ -904,7 +904,7 @@ impl App {
                             let song_name =
                                 format!("{} - {}", message.artist_name, message.song_name);
 
-                            if results_label.text().as_str() != &song_name {
+                            if results_label.text().as_str() != song_name {
                                 results_label.set_label(&song_name);
 
                                 let notification =
@@ -920,7 +920,7 @@ impl App {
 
                                         match message.album_name {
                                             Some(ref value) => {
-                                                results_image.set_tooltip_text(Some(&value))
+                                                results_image.set_tooltip_text(Some(value))
                                             }
                                             None => results_image.set_tooltip_text(None),
                                         };
@@ -957,7 +957,7 @@ impl App {
                                 }
 
                                 let new_entry = SongHistoryRecord {
-                                    song_name: song_name,
+                                    song_name,
                                     album: Some(
                                         message
                                             .album_name
@@ -1025,7 +1025,7 @@ impl App {
                                 if old_device_name == Some(device.inner_name.to_string()) {
                                     initial_device_index = current_index;
                                     initial_device = Some(listed_device);
-                                } else if old_device_name == None
+                                } else if old_device_name.is_none()
                                     && device.is_monitor
                                     && !found_monitor_device
                                 {
@@ -1074,7 +1074,7 @@ impl App {
 
                         WipeSongHistory => {
                             let dialog = adw::AlertDialog::builder()
-                                .body(&gettext("Are you sure you want to wipe history?"))
+                                .body(gettext("Are you sure you want to wipe history?"))
                                 .default_response("yes")
                                 .close_response("no")
                                 .build();
@@ -1138,7 +1138,7 @@ impl App {
                 about_dialog.set_version(env!("CARGO_PKG_VERSION"));
                 about_dialog.present(Some(window));
 
-                about_dialog.set_debug_info(&*ctx_buffered_log.borrow());
+                about_dialog.set_debug_info(&ctx_buffered_log.borrow());
 
                 // Sync the debug info with the About modal at most every
                 // 1 sec as it may require a lot of text rendering power
@@ -1148,11 +1148,11 @@ impl App {
                 let ctx_logger_source_id_2 = ctx_logger_source_id.clone();
                 let about_dialog = about_dialog.clone();
 
-                if *ctx_logger_source_id.borrow() == None {
+                if (*ctx_logger_source_id.borrow()).is_none() {
                     *ctx_logger_source_id.borrow_mut() =
                         Some(glib::source::timeout_add_seconds_local(1, move || {
                             if about_dialog.is_visible() {
-                                about_dialog.set_debug_info(&*ctx_buffered_log.borrow());
+                                about_dialog.set_debug_info(&ctx_buffered_log.borrow());
                                 glib::ControlFlow::Continue
                             } else {
                                 *ctx_logger_source_id_2.borrow_mut() = None;

--- a/src/gui/song_history_interface.rs
+++ b/src/gui/song_history_interface.rs
@@ -10,9 +10,9 @@ use std::collections::HashSet;
 use std::error::Error;
 
 trait SongHistoryRecordListStore {
-    fn add_song_history_record(self: &mut Self, to_add: &SongHistoryRecord);
-    fn remove_song(self: &mut Self, to_remove: Song);
-    fn remove_song_history_record(self: &mut Self, to_remove: SongHistoryRecord);
+    fn add_song_history_record(&mut self, to_add: &SongHistoryRecord);
+    fn remove_song(&mut self, to_remove: Song);
+    fn remove_song_history_record(&mut self, to_remove: SongHistoryRecord);
 }
 
 // Extend gio::ListStore to integrate with SongHistoryRecord
@@ -22,11 +22,11 @@ impl SongHistoryRecordListStore for gio::ListStore {
     // This function first will be the first interacting with the ListStore
     // to be called after installing a fresh copy of the app
 
-    fn add_song_history_record(self: &mut Self, to_add: &SongHistoryRecord) {
+    fn add_song_history_record(&mut self, to_add: &SongHistoryRecord) {
         self.insert(0, &HistoryEntry::new(to_add));
     }
 
-    fn remove_song(self: &mut Self, to_remove: Song) {
+    fn remove_song(&mut self, to_remove: Song) {
         // Cf. https://gtk-rs.org/gtk-rs-core/git/docs/gio/struct.ListStore.html#method.remove
         // (Note: Song is SongHistoryRecord minus the recognition date)
         // This removes all items with the matching Song footprint
@@ -36,7 +36,7 @@ impl SongHistoryRecordListStore for gio::ListStore {
         })
     }
 
-    fn remove_song_history_record(self: &mut Self, to_remove: SongHistoryRecord) {
+    fn remove_song_history_record(&mut self, to_remove: SongHistoryRecord) {
         self.remove_song(to_remove.get_song());
     }
 }
@@ -61,12 +61,12 @@ pub trait SongRecordInterface {
     where
         Self: Sized;
 
-    fn wipe_and_save(self: &mut Self);
-    fn add_row_and_save(self: &mut Self, record: SongHistoryRecord);
+    fn wipe_and_save(&mut self);
+    fn add_row_and_save(&mut self, record: SongHistoryRecord);
 
-    fn load(self: &mut Self) -> Result<(), Box<dyn Error>>;
-    fn remove(self: &mut Self, record: SongHistoryRecord);
-    fn save(self: &mut Self);
+    fn load(&mut self) -> Result<(), Box<dyn Error>>;
+    fn remove(&mut self, record: SongHistoryRecord);
+    fn save(&mut self);
 }
 
 impl dyn SongRecordInterface {}
@@ -99,7 +99,7 @@ impl SongRecordInterface for RecognitionHistoryInterface {
         Ok(interface)
     }
 
-    fn load(self: &mut Self) -> Result<(), Box<dyn Error>> {
+    fn load(&mut self) -> Result<(), Box<dyn Error>> {
         match csv::ReaderBuilder::new()
             .flexible(true)
             .from_path(&self.csv_path)
@@ -122,7 +122,7 @@ impl SongRecordInterface for RecognitionHistoryInterface {
         Ok(())
     }
 
-    fn wipe_and_save(self: &mut Self) {
+    fn wipe_and_save(&mut self) {
         self.list_store.remove_all();
 
         let mut writer = csv::Writer::from_path(&self.csv_path).unwrap();
@@ -130,13 +130,13 @@ impl SongRecordInterface for RecognitionHistoryInterface {
         writer.flush().unwrap();
     }
 
-    fn add_row_and_save(self: &mut Self, record: SongHistoryRecord) {
+    fn add_row_and_save(&mut self, record: SongHistoryRecord) {
         self.list_store.add_song_history_record(&record);
 
         self.save();
     }
 
-    fn save(self: &mut Self) {
+    fn save(&mut self) {
         let mut writer = csv::Writer::from_path(&self.csv_path).unwrap();
 
         for item in self.list_store.iter::<glib::Object>() {
@@ -146,7 +146,7 @@ impl SongRecordInterface for RecognitionHistoryInterface {
         writer.flush().unwrap();
     }
 
-    fn remove(self: &mut Self, song_record: SongHistoryRecord) {
+    fn remove(&mut self, song_record: SongHistoryRecord) {
         self.list_store.remove_song_history_record(song_record);
         self.save()
     }
@@ -174,7 +174,7 @@ impl SongRecordInterface for FavoritesInterface {
         Ok(interface)
     }
 
-    fn load(self: &mut Self) -> Result<(), Box<dyn Error>> {
+    fn load(&mut self) -> Result<(), Box<dyn Error>> {
         match csv::ReaderBuilder::new()
             .flexible(true)
             .from_path(&self.csv_path)
@@ -191,7 +191,7 @@ impl SongRecordInterface for FavoritesInterface {
         Ok(())
     }
 
-    fn wipe_and_save(self: &mut Self) {
+    fn wipe_and_save(&mut self) {
         self.list_store.remove_all();
         self.is_favorite.clear();
         let mut writer = csv::Writer::from_path(&self.csv_path).unwrap();
@@ -199,13 +199,13 @@ impl SongRecordInterface for FavoritesInterface {
         writer.flush().unwrap();
     }
 
-    fn add_row_and_save(self: &mut Self, record: SongHistoryRecord) {
+    fn add_row_and_save(&mut self, record: SongHistoryRecord) {
         self.list_store.add_song_history_record(&record);
         self.is_favorite.insert(record.get_song());
         self.save();
     }
 
-    fn save(self: &mut Self) {
+    fn save(&mut self) {
         let mut writer = csv::Writer::from_path(&self.csv_path).unwrap();
 
         for item in self.list_store.iter::<glib::Object>() {
@@ -215,7 +215,7 @@ impl SongRecordInterface for FavoritesInterface {
         writer.flush().unwrap();
     }
 
-    fn remove(self: &mut Self, song_record: SongHistoryRecord) {
+    fn remove(&mut self, song_record: SongHistoryRecord) {
         let song = song_record.get_song();
         self.is_favorite.remove(&song);
         self.list_store.remove_song(song);

--- a/src/gui/song_history_interface.rs
+++ b/src/gui/song_history_interface.rs
@@ -100,25 +100,20 @@ impl SongRecordInterface for RecognitionHistoryInterface {
     }
 
     fn load(&mut self) -> Result<(), Box<dyn Error>> {
-        match csv::ReaderBuilder::new()
+        if let Ok(mut reader) = csv::ReaderBuilder::new()
             .flexible(true)
             .from_path(&self.csv_path)
         {
-            Ok(mut reader) => {
-                let mut read = reader.deserialize().collect::<Vec<_>>();
-                fn item_date(
-                    item: &csv::Result<SongHistoryRecord>,
-                ) -> Option<chrono::NaiveDateTime> {
-                    let s = &item.as_ref().ok()?.recognition_date;
-                    chrono::NaiveDateTime::parse_from_str(s, "%c").ok()
-                }
-                read.sort_by_cached_key(item_date);
-                for result in read {
-                    self.list_store.add_song_history_record(&result?)
-                }
+            let mut read = reader.deserialize().collect::<Vec<_>>();
+            fn item_date(item: &csv::Result<SongHistoryRecord>) -> Option<chrono::NaiveDateTime> {
+                let s = &item.as_ref().ok()?.recognition_date;
+                chrono::NaiveDateTime::parse_from_str(s, "%c").ok()
             }
-            _ => {} // File does not exists, ignore
-        };
+            read.sort_by_cached_key(item_date);
+            for result in read {
+                self.list_store.add_song_history_record(&result?)
+            }
+        }
         Ok(())
     }
 
@@ -175,19 +170,16 @@ impl SongRecordInterface for FavoritesInterface {
     }
 
     fn load(&mut self) -> Result<(), Box<dyn Error>> {
-        match csv::ReaderBuilder::new()
+        if let Ok(mut reader) = csv::ReaderBuilder::new()
             .flexible(true)
             .from_path(&self.csv_path)
         {
-            Ok(mut reader) => {
-                for result in reader.deserialize() {
-                    let record = result?;
-                    self.list_store.add_song_history_record(&record);
-                    self.is_favorite.insert(record.get_song());
-                }
+            for result in reader.deserialize() {
+                let record = result?;
+                self.list_store.add_song_history_record(&record);
+                self.is_favorite.insert(record.get_song());
             }
-            _ => {} // File does not exists, ignore
-        };
+        }
         Ok(())
     }
 

--- a/src/plugins/ffmpeg_wrapper.rs
+++ b/src/plugins/ffmpeg_wrapper.rs
@@ -61,7 +61,7 @@ pub fn decode_with_ffmpeg(file_path: &str) -> Option<rodio::Decoder<BufReader<st
 
         let mut command = Command::new(ffmpeg_path);
 
-        let command = command.args(&["-y", "-i", file_path, sink_file_path.to_str().unwrap()]);
+        let command = command.args(["-y", "-i", file_path, sink_file_path.to_str().unwrap()]);
 
         debug!("Spawning ffmpeg: {:?}", command);
 

--- a/src/plugins/ffmpeg_wrapper.rs
+++ b/src/plugins/ffmpeg_wrapper.rs
@@ -9,7 +9,6 @@ use std::process::Command;
 /// This function used to decode a file with FFMpeg, if it is installed on
 /// the system, in the case where Rodio can't decode the concerned format
 /// (for example with .WMA, .M4A, etc.).
-
 pub fn decode_with_ffmpeg(file_path: &str) -> Option<rodio::Decoder<BufReader<std::fs::File>>> {
     // Find the path for FFMpeg, in the case where it is installed
 

--- a/src/plugins/ksni.rs
+++ b/src/plugins/ksni.rs
@@ -45,7 +45,7 @@ impl ksni::Tray for SystrayInterface {
         use ksni::menu::*;
         vec![
             StandardItem {
-                label: gettext("Open SongRec").into(),
+                label: gettext("Open SongRec"),
                 activate: Box::new(|tray: &mut Self| {
                     tray.gui_tx.try_send(GUIMessage::ShowWindow).unwrap();
                 }),
@@ -53,7 +53,7 @@ impl ksni::Tray for SystrayInterface {
             }
             .into(),
             StandardItem {
-                label: gettext("Quit...").into(),
+                label: gettext("Quit..."),
                 activate: Box::new(|tray: &mut Self| {
                     tray.gui_tx.try_send(GUIMessage::QuitApplication).unwrap();
                 }),

--- a/src/utils/csv_song_history.rs
+++ b/src/utils/csv_song_history.rs
@@ -40,54 +40,18 @@ pub trait HasSong {
 
 impl HasSong for Song {
     fn get_song(self) -> Song {
-        return self;
+        self
     }
 }
 
 impl HasSong for SongHistoryRecord {
     fn get_song(self) -> Song {
-        return Song {
+        Song {
             song_name: self.song_name,
-            album: match self.album {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-            track_key: match self.track_key {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-            release_year: match self.release_year {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-            genre: match self.genre {
-                Some(val) => {
-                    if &val == "" {
-                        None
-                    } else {
-                        Some(val)
-                    }
-                }
-                None => None,
-            },
-        };
+            album: self.album.filter(|val| !val.is_empty()),
+            track_key: self.track_key.filter(|val| !val.is_empty()),
+            release_year: self.release_year.filter(|val| !val.is_empty()),
+            genre: self.genre.filter(|val| !val.is_empty()),
+        }
     }
 }

--- a/src/utils/filesystem_operations.rs
+++ b/src/utils/filesystem_operations.rs
@@ -72,16 +72,14 @@ pub fn obtain_cache_directory() -> Result<PathBuf, Box<dyn Error>> {
 
 pub fn clear_cache() {
     if let Ok(contents) = std::fs::read_dir(obtain_cache_directory().unwrap()) {
-        for entry in contents {
-            if let Ok(entry) = entry {
-                if entry
-                    .file_name()
-                    .to_str()
-                    .unwrap_or("")
-                    .starts_with("songrec_cover_")
-                {
-                    std::fs::remove_file(entry.path()).ok();
-                }
+        for entry in contents.flatten() {
+            if entry
+                .file_name()
+                .to_str()
+                .unwrap_or("")
+                .starts_with("songrec_cover_")
+            {
+                std::fs::remove_file(entry.path()).ok();
             }
         }
     }

--- a/src/utils/internationalization.rs
+++ b/src/utils/internationalization.rs
@@ -2,10 +2,7 @@ use gettextrs::{bind_textdomain_codeset, bindtextdomain, setlocale, textdomain, 
 use log::warn;
 use std::path::PathBuf;
 
-/**
- * Set up the translation/internationalization part
- */
-
+/// Set up the translation/internationalization part
 pub fn setup_internationalization() -> Option<PathBuf> {
     // First, check for a "translations" directory in the
     // same directory as the current binary


### PR DESCRIPTION
Clippy is very useful to run from time to time, it finds suboptimal patterns and provides guidance in how to fix them.

I’ve reviewed every single one of the automated changes and they all seem valid.

In the second commit I’ve manually fixed the ones it wasn’t sure how to fix, and it simplified things even more.

The last two warnings are about a function taking too many arguments (which shouldn’t be a big issue), and one where the proposed fix is significantly harder to read.