### PR TITLE
Remove some useless mutexes

### DIFF
--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -5,25 +5,21 @@ use log::Level;
 use std::boxed::Box;
 use std::collections::HashMap;
 use std::io::Write;
-use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "gui")]
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct GUIDispatcher {
-    #[cfg(feature = "gui")]
-    gui_tx: Arc<Mutex<Option<async_channel::Sender<GUIMessage>>>>,
+    gui_tx: Option<async_channel::Sender<GUIMessage>>,
 }
 
 #[cfg(feature = "gui")]
 impl GUIDispatcher {
     fn new() -> Self {
-        Self {
-            gui_tx: Arc::new(Mutex::new(None)),
-        }
+        Self::default()
     }
 
-    fn connect_to_gui_logger(&self, gui_tx: async_channel::Sender<GUIMessage>) {
-        *self.gui_tx.lock().unwrap() = Some(gui_tx);
+    fn connect_to_gui_logger(&mut self, gui_tx: async_channel::Sender<GUIMessage>) {
+        self.gui_tx = Some(gui_tx);
     }
 }
 
@@ -31,7 +27,7 @@ impl GUIDispatcher {
 impl Write for GUIDispatcher {
     fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
         #[cfg(feature = "gui")]
-        if let Some(ref gui_tx) = *self.gui_tx.lock().unwrap() {
+        if let Some(ref gui_tx) = self.gui_tx {
             gui_tx
                 .try_send(GUIMessage::AppendToLog(
                     String::from_utf8_lossy(buf).into_owned(),
@@ -45,9 +41,6 @@ impl Write for GUIDispatcher {
         Ok(())
     }
 }
-
-#[cfg(feature = "gui")]
-unsafe impl std::marker::Send for GUIDispatcher {}
 
 pub struct Logging {
     #[cfg(feature = "gui")]
@@ -105,7 +98,7 @@ impl Logging {
     }
 
     #[cfg(feature = "gui")]
-    pub fn connect_to_gui_logger(self, gui_tx: async_channel::Sender<GUIMessage>) {
+    pub fn connect_to_gui_logger(mut self, gui_tx: async_channel::Sender<GUIMessage>) {
         self.gui_dispatcher.connect_to_gui_logger(gui_tx);
     }
 

--- a/src/core/microphone_thread.rs
+++ b/src/core/microphone_thread.rs
@@ -1,6 +1,7 @@
 use std::iter::Copied;
 use std::num::NonZero;
 use std::slice::Iter;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::core::preferences::PreferencesInterface;
@@ -36,7 +37,7 @@ pub fn microphone_thread(
 
     let mut stream: Option<cpal::Stream> = None;
 
-    let processing_already_ongoing: Arc<Mutex<bool>> = Arc::new(Mutex::new(false)); // Whether our data is already being processed in other threads (pointer to a bool shared between this thread and the CPAL thread, hence the Arc<Mutex>)
+    let processing_already_ongoing: Arc<AtomicBool> = Arc::new(AtomicBool::new(false)); // Whether our data is already being processed in other threads (pointer to a bool shared between this thread and the CPAL thread, hence the Arc<AtomicBool>)
 
     // Send a list of the active microphone-alike devices to the GUI thread
     // (the combo box will be filed with device names when a "DevicesList"
@@ -233,9 +234,7 @@ pub fn microphone_thread(
             }
 
             ProcessingDone => {
-                let mut processing_already_ongoing_borrow =
-                    processing_already_ongoing.lock().unwrap();
-                *processing_already_ongoing_borrow = false;
+                processing_already_ongoing.store(false, Ordering::SeqCst);
             }
         }
     }
@@ -250,7 +249,7 @@ fn write_data(
     twelve_seconds_buffer: &mut [f32],
     number_unprocessed_samples: &mut usize,
     number_unmeasured_samples: &mut usize,
-    processing_already_ongoing: &Arc<Mutex<bool>>,
+    processing_already_ongoing: &AtomicBool,
     preferences_interface: &Arc<Mutex<PreferencesInterface>>,
 ) {
     // Reassemble data into a 12-second buffer, and do recognition
@@ -289,10 +288,8 @@ fn write_data(
 
     *number_unprocessed_samples += raw_pcm_samples.len();
 
-    let mut processing_already_ongoing_borrow = processing_already_ongoing.lock().unwrap();
-
     if *number_unprocessed_samples >= 16000 * request_interval_secs
-        && !*processing_already_ongoing_borrow
+        && !processing_already_ongoing.load(Ordering::SeqCst)
     {
         if !twelve_seconds_buffer.iter().all(|x| *x == 0.0) {
             processing_tx
@@ -301,7 +298,7 @@ fn write_data(
                 ))
                 .unwrap();
 
-            *processing_already_ongoing_borrow = true;
+            processing_already_ongoing.store(true, Ordering::SeqCst);
         }
 
         *number_unprocessed_samples = 0;

--- a/src/core/preferences.rs
+++ b/src/core/preferences.rs
@@ -105,7 +105,7 @@ impl PreferencesInterface {
     }
 
     pub fn update(&mut self, update_preferences: Preferences) {
-        let current_preferences = self.preferences.clone();
+        let current_preferences = &self.preferences;
         self.preferences = Preferences {
             enable_notifications: update_preferences
                 .enable_notifications
@@ -141,7 +141,7 @@ impl PreferencesInterface {
                 .or(current_preferences.request_interval_secs_v3),
             current_device_name: update_preferences
                 .current_device_name
-                .or(current_preferences.current_device_name),
+                .or_else(|| current_preferences.current_device_name.clone()),
         };
         if let Err(error) = self.write() {
             error!("{} {}", gettext("When saving the preferences file:"), error);


### PR DESCRIPTION
`async_channel::Sender<_>` is already `Send` and `Sync`, and we can replace `Arc<Mutex<bool>>` with `Arc<AtomicBool>` for much better performances on modern architectures.