### PR TITLE
Remove some unnecessary allocations

### DIFF
--- a/src/core/audio_controllers/cpal.rs
+++ b/src/core/audio_controllers/cpal.rs
@@ -45,8 +45,8 @@ impl AudioBackend for CpalBackend {
             }
 
             device_names.push(DeviceListItem {
-                inner_name: device_id.clone(),
-                display_name: device_name.clone(),
+                inner_name: device_id,
+                display_name: device_name,
                 is_monitor: device_description.direction() != DeviceDirection::Input,
             });
         }

--- a/src/core/audio_controllers/pulseaudio.rs
+++ b/src/core/audio_controllers/pulseaudio.rs
@@ -36,7 +36,7 @@ impl PulseBackend {
 
         let applications = self.handler.list_applications().unwrap();
 
-        let criteria: Vec<String> = vec![
+        let criteria: [String; _] = [
             format!("process.id = \"{}\"", std::process::id()),
             "alsa plug-in [songrec]".to_string(),
             "songrec".to_string(),
@@ -44,7 +44,7 @@ impl PulseBackend {
         ];
 
         for criterion in criteria {
-            for app in applications.clone() {
+            for app in &applications {
                 if app
                     .proplist
                     .to_string()

--- a/src/core/fingerprinting/communication.rs
+++ b/src/core/fingerprinting/communication.rs
@@ -128,7 +128,7 @@ pub async fn recognize_song_from_signature(
 }
 
 pub async fn obtain_raw_cover_image(
-    session: soup::Session,
+    session: &soup::Session,
     url: &str,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
     let message = soup::Message::new("GET", url)?;

--- a/src/core/http_task.rs
+++ b/src/core/http_task.rs
@@ -66,7 +66,7 @@ async fn try_recognize_song(
             }
         },
         cover_image: match &json_object["track"]["images"]["coverart"] {
-            Value::String(string) => Some(obtain_raw_cover_image(session.clone(), string).await?),
+            Value::String(string) => Some(obtain_raw_cover_image(session, string).await?),
             _ => None,
         },
         track_key: match &json_object["track"]["key"] {

--- a/src/gui/history_entry/mod.rs
+++ b/src/gui/history_entry/mod.rs
@@ -9,12 +9,12 @@ glib::wrapper! {
 impl HistoryEntry {
     pub fn new(song: &SongHistoryRecord) -> Self {
         glib::Object::builder()
-            .property("song_name", song.song_name.clone())
-            .property("album", song.album.clone())
-            .property("track_key", song.track_key.clone())
-            .property("release_year", song.release_year.clone())
-            .property("genre", song.genre.clone())
-            .property("recognition_date", song.recognition_date.clone())
+            .property("song_name", &song.song_name)
+            .property("album", &song.album)
+            .property("track_key", &song.track_key)
+            .property("release_year", &song.release_year)
+            .property("genre", &song.genre)
+            .property("recognition_date", &song.recognition_date)
             .build()
 
         /*

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -316,9 +316,7 @@ impl App {
         ctx_systray_handle: Rc<RefCell<Option<ksni::Handle<SystrayInterface>>>>,
         window: adw::ApplicationWindow,
     ) {
-        let window = window.clone();
         glib::spawn_future_local(async move {
-            let ctx_systray_handle = ctx_systray_handle.clone();
             if let Some(handle) = ctx_systray_handle.take() {
                 window.set_hide_on_close(false);
                 *ctx_systray_handle.borrow_mut() = None;
@@ -754,14 +752,14 @@ impl App {
                         debug!(
                             "Received GUI message: SongRecognized({})",
                             json!({
-                                "artist_name": msg.artist_name.clone(),
-                                "album_name": msg.album_name.clone(),
-                                "song_name": msg.song_name.clone(),
+                                "artist_name": msg.artist_name,
+                                "album_name": msg.album_name,
+                                "song_name": msg.song_name,
                                 "cover_image": msg.cover_image.as_ref().map(|data| format!("{:02x?}...", &data[..16])),
-                                "track_key": msg.track_key.clone(),
-                                "release_year": msg.release_year.clone(),
-                                "genre": msg.genre.clone(),
-                                "shazam_json": msg.shazam_json.clone()
+                                "track_key": msg.track_key,
+                                "release_year": msg.release_year,
+                                "genre": msg.genre,
+                                "shazam_json": msg.shazam_json,
                             })
                         );
                     } else {
@@ -835,7 +833,7 @@ impl App {
                                     Self::notify_application_error(
                                         preferences_interface_ptr.clone(),
                                         &string,
-                                        &application.clone(),
+                                        &application,
                                     );
                                 }
                             }
@@ -845,7 +843,7 @@ impl App {
                                 Self::notify_network_error(
                                     preferences_interface_ptr.clone(),
                                     &rate_limited_message.label(),
-                                    &application.clone(),
+                                    &application,
                                     true,
                                 );
                             }
@@ -856,7 +854,7 @@ impl App {
                                 Self::notify_network_error(
                                     preferences_interface_ptr.clone(),
                                     &no_network_message.label(),
-                                    &application.clone(),
+                                    &application,
                                     false,
                                 );
                             }
@@ -1212,7 +1210,7 @@ impl App {
                     glib::spawn_future_local(async move {
                         let launch_path = obtain_recognition_history_csv_path().unwrap();
                         info!("Launching file: {}", launch_path);
-                        let launch_file = gio::File::for_path(launch_path.clone());
+                        let launch_file = gio::File::for_path(&launch_path);
                         if let Err(err) = gtk::FileLauncher::new(Some(&launch_file))
                             .launch_future(Some(&window))
                             .await
@@ -1243,7 +1241,7 @@ impl App {
                     glib::spawn_future_local(async move {
                         let launch_path = obtain_favorites_csv_path().unwrap();
                         info!("Launching file: {}", launch_path);
-                        let launch_file = gio::File::for_path(launch_path.clone());
+                        let launch_file = gio::File::for_path(&launch_path);
                         if let Err(err) = gtk::FileLauncher::new(Some(&launch_file))
                             .launch_future(Some(&window))
                             .await

--- a/src/plugins/mpris_player.rs
+++ b/src/plugins/mpris_player.rs
@@ -49,13 +49,13 @@ pub async fn update_song(
     last_cover_path: &mut Option<std::path::PathBuf>,
 ) {
     let mut metadata = Metadata::builder()
-        .title(message.song_name.clone())
-        .artist(vec![message.artist_name.clone()]);
-    if let Some(ref album) = message.album_name {
-        metadata = metadata.album(album.clone());
+        .title(&message.song_name)
+        .artist([&message.artist_name]);
+    if let Some(album) = &message.album_name {
+        metadata = metadata.album(album);
     }
-    if let Some(ref genre) = message.genre {
-        metadata = metadata.genre(vec![genre.clone()]);
+    if let Some(genre) = &message.genre {
+        metadata = metadata.genre([genre]);
     }
 
     // Clean up old cover file


### PR DESCRIPTION
`Vec` and `String` being used instead of their borrowed equivalent, or `clone` being used when unneeded.