### PR TITLE
Keep PathBuf as long as possible to represent paths

### DIFF
--- a/src/core/preferences.rs
+++ b/src/core/preferences.rs
@@ -3,6 +3,7 @@ use log::{debug, error};
 use serde::Deserialize;
 use serde::Serialize;
 use std::error::Error;
+use std::path::PathBuf;
 
 use crate::utils::filesystem_operations::obtain_preferences_file_path;
 
@@ -72,7 +73,7 @@ impl Default for Preferences {
 
 #[derive(Clone, Debug)]
 pub struct PreferencesInterface {
-    pub preferences_file_path: Option<String>,
+    pub preferences_file_path: Option<PathBuf>,
     pub preferences: Preferences,
 }
 
@@ -91,12 +92,13 @@ impl PreferencesInterface {
     }
 
     fn load() -> Result<PreferencesInterface, Box<dyn Error>> {
-        let preferences_file_path: String = obtain_preferences_file_path()?;
+        let preferences_file_path = obtain_preferences_file_path()?;
         let contents = std::fs::read_to_string(&preferences_file_path).unwrap_or_default();
         let preferences: Preferences = toml::from_str(&contents)?;
         debug!(
             "Loaded preferences from {}: {:?}",
-            preferences_file_path, preferences
+            preferences_file_path.display(),
+            preferences
         );
         Ok(PreferencesInterface {
             preferences_file_path: Some(preferences_file_path),

--- a/src/gui/main_window.rs
+++ b/src/gui/main_window.rs
@@ -1209,13 +1209,13 @@ impl App {
 
                     glib::spawn_future_local(async move {
                         let launch_path = obtain_recognition_history_csv_path().unwrap();
-                        info!("Launching file: {}", launch_path);
+                        info!("Launching file: {}", launch_path.display());
                         let launch_file = gio::File::for_path(&launch_path);
                         if let Err(err) = gtk::FileLauncher::new(Some(&launch_file))
                             .launch_future(Some(&window))
                             .await
                         {
-                            error!("Could not launch file {}: {:?}", launch_path, err);
+                            error!("Could not launch file {}: {:?}", launch_path.display(), err);
                         }
                     });
                 }
@@ -1240,13 +1240,13 @@ impl App {
 
                     glib::spawn_future_local(async move {
                         let launch_path = obtain_favorites_csv_path().unwrap();
-                        info!("Launching file: {}", launch_path);
+                        info!("Launching file: {}", launch_path.display());
                         let launch_file = gio::File::for_path(&launch_path);
                         if let Err(err) = gtk::FileLauncher::new(Some(&launch_file))
                             .launch_future(Some(&window))
                             .await
                         {
-                            error!("Could not launch file {}: {:?}", launch_path, err);
+                            error!("Could not launch file {}: {:?}", launch_path.display(), err);
                         }
                     });
                 }

--- a/src/gui/song_history_interface.rs
+++ b/src/gui/song_history_interface.rs
@@ -8,6 +8,7 @@ use gtk::prelude::*;
 use log::error;
 use std::collections::HashSet;
 use std::error::Error;
+use std::path::PathBuf;
 
 trait SongHistoryRecordListStore {
     fn add_song_history_record(&mut self, to_add: &SongHistoryRecord);
@@ -43,12 +44,12 @@ impl SongHistoryRecordListStore for gio::ListStore {
 
 #[derive(Debug, Clone)]
 pub struct RecognitionHistoryInterface {
-    csv_path: String,
+    csv_path: PathBuf,
     list_store: gio::ListStore,
 }
 #[derive(Debug, Clone)]
 pub struct FavoritesInterface {
-    csv_path: String,
+    csv_path: PathBuf,
     list_store: gio::ListStore,
     is_favorite: HashSet<Song>,
 }
@@ -56,7 +57,7 @@ pub struct FavoritesInterface {
 pub trait SongRecordInterface {
     fn new(
         list_store: gio::ListStore,
-        get_csv_path: fn() -> Result<String, Box<dyn Error>>,
+        get_csv_path: fn() -> Result<PathBuf, Box<dyn Error>>,
     ) -> Result<Self, Box<dyn Error>>
     where
         Self: Sized;
@@ -81,7 +82,7 @@ fn test_item_date() {
 impl SongRecordInterface for RecognitionHistoryInterface {
     fn new(
         list_store: gio::ListStore,
-        get_csv_path: fn() -> Result<String, Box<dyn Error>>,
+        get_csv_path: fn() -> Result<PathBuf, Box<dyn Error>>,
     ) -> Result<Self, Box<dyn Error>> {
         let mut interface = RecognitionHistoryInterface {
             csv_path: get_csv_path()?,
@@ -150,7 +151,7 @@ impl SongRecordInterface for RecognitionHistoryInterface {
 impl SongRecordInterface for FavoritesInterface {
     fn new(
         list_store: gio::ListStore,
-        get_csv_path: fn() -> Result<String, Box<dyn Error>>,
+        get_csv_path: fn() -> Result<PathBuf, Box<dyn Error>>,
     ) -> Result<Self, Box<dyn Error>> {
         let mut interface = FavoritesInterface {
             csv_path: get_csv_path()?,

--- a/src/utils/filesystem_operations.rs
+++ b/src/utils/filesystem_operations.rs
@@ -6,38 +6,36 @@ use std::fs::create_dir_all;
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_dir;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+use std::sync::LazyLock;
 
 const QUALIFIER: &str = "";
 const ORGANIZATION: &str = "SongRec";
 const APPLICATION: &str = "SongRec";
 
-pub fn obtain_recognition_history_csv_path() -> Result<String, Box<dyn Error>> {
-    let project_dir =
-        ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or("No valid path")?;
-    let mut csv_path: PathBuf = obtain_data_directory(project_dir)?;
+static PROJECT_DIRS: LazyLock<ProjectDirs> =
+    LazyLock::new(|| ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).unwrap());
+
+pub fn obtain_recognition_history_csv_path() -> Result<PathBuf, Box<dyn Error>> {
+    let mut csv_path = obtain_data_directory()?;
     csv_path.push("song_history.csv");
-    Ok(csv_path.to_str().unwrap().to_string())
+    Ok(csv_path)
 }
 
-pub fn obtain_favorites_csv_path() -> Result<String, Box<dyn Error>> {
-    let project_dir =
-        ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or("No valid path")?;
-    let mut csv_path: PathBuf = obtain_data_directory(project_dir)?;
+pub fn obtain_favorites_csv_path() -> Result<PathBuf, Box<dyn Error>> {
+    let mut csv_path = obtain_data_directory()?;
     csv_path.push("favorites.csv");
-    Ok(csv_path.to_str().unwrap().to_string())
+    Ok(csv_path)
 }
 
-pub fn obtain_preferences_file_path() -> Result<String, Box<dyn Error>> {
-    let project_dir =
-        ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or("No valid path")?;
-    let mut preferences_file_path: PathBuf = obtain_preferences_directory(project_dir)?;
+pub fn obtain_preferences_file_path() -> Result<PathBuf, Box<dyn Error>> {
+    let mut preferences_file_path = obtain_preferences_directory()?;
     preferences_file_path.push("preferences.toml");
-    Ok(preferences_file_path.to_str().unwrap().to_string())
+    Ok(preferences_file_path)
 }
 
-fn obtain_data_directory(project_directory: ProjectDirs) -> Result<PathBuf, Box<dyn Error>> {
-    let data_dir: &Path = project_directory.data_dir();
+fn obtain_data_directory() -> Result<PathBuf, Box<dyn Error>> {
+    let data_dir = PROJECT_DIRS.data_dir();
     if !data_dir.exists() {
         let old_dir = get_old_data_dir_path()?;
         if old_dir.exists() {
@@ -52,8 +50,8 @@ fn obtain_data_directory(project_directory: ProjectDirs) -> Result<PathBuf, Box<
     Ok(data_dir.to_path_buf())
 }
 
-fn obtain_preferences_directory(project_directory: ProjectDirs) -> Result<PathBuf, Box<dyn Error>> {
-    let preferences_dir: &Path = project_directory.preference_dir();
+fn obtain_preferences_directory() -> Result<PathBuf, Box<dyn Error>> {
+    let preferences_dir = PROJECT_DIRS.preference_dir();
     if !preferences_dir.exists() {
         create_dir_all(preferences_dir)?;
     }
@@ -61,9 +59,7 @@ fn obtain_preferences_directory(project_directory: ProjectDirs) -> Result<PathBu
 }
 
 pub fn obtain_cache_directory() -> Result<PathBuf, Box<dyn Error>> {
-    let project_dir =
-        ProjectDirs::from(QUALIFIER, ORGANIZATION, APPLICATION).ok_or("No valid path")?;
-    let cache_path = project_dir.cache_dir();
+    let cache_path = PROJECT_DIRS.cache_dir();
     if !cache_path.exists() {
         create_dir_all(cache_path)?;
     }


### PR DESCRIPTION
There is no need to convert them into `String`, this is an allocation and complexifies the API for no reason.

Also hoist the `ProjectDirs` into a `static LazyLock`.