### PR TITLE
Fix CLI output on Windows (Issue #289)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![windows_subsystem = "windows"]
+#![cfg_attr(feature = "gui", windows_subsystem = "windows")]
 
 pub mod cli_main;
 


### PR DESCRIPTION
`#![windows_subsystem = "windows"]` was blocking CLI output. This makes it conditional on the gui feature so CLI-only builds work. 

Verified with `objcopy` (MSYS2 MINGW64).
Fixes #289