### PR TITLE
Remove unused gdk-pixbuf dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,7 +2480,6 @@ dependencies = [
  "directories",
  "fern",
  "flate2",
- "gdk-pixbuf",
  "gdk4",
  "gettext-rs",
  "gettext-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ gdk = { version = "0.10.3", package = "gdk4", optional = true }
 gio = { version = "0.21.5", features = ["v2_74"], optional = true }
 percent-encoding = { version = "2.1.0", optional = true } # For percent-encoding contents in URLs
 chrono = { version = "0.4.13" } # For formatting dates
-gdk-pixbuf = { version = "0.21.5", optional = true }
 directories = {version = "6.0" }
 toml = "1.0.1"
 app_dirs = { version = "1.2.1" } # For obtaining and creating either the %APPDATA%, the dotfile path or similar
@@ -63,7 +62,7 @@ glib-build-tools = "0.21.0"
 
 [features]
 default = ["gui", "ffmpeg", "pulse", "mpris", "pipewire" ]
-gui = ["gtk", "adw", "gdk", "gio", "percent-encoding", "ksni", "gdk-pixbuf"]
+gui = ["gtk", "adw", "gdk", "gio", "percent-encoding", "ksni"]
 pulse = [ "pulsectl-rs", "libpulse-binding" ]
 mpris = [ "mpris-server" ]
 pipewire = []


### PR DESCRIPTION
It’s still present as a dependency of the `gtk4` crate though.