### PR TITLE
Make `twelve_seconds_buffer` know its own size

### DIFF
--- a/src/core/microphone_thread.rs
+++ b/src/core/microphone_thread.rs
@@ -24,7 +24,7 @@ struct ProcessingState<'a> {
     gui_tx: async_channel::Sender<GUIMessage>,
     channels: u16,
     sample_rate: u32,
-    twelve_seconds_buffer: &'a mut [f32],
+    twelve_seconds_buffer: &'a mut Box<[f32; 16000 * MAX_BUFFER_SIZE]>,
     number_unprocessed_samples: &'a mut usize,
     number_unmeasured_samples: &'a mut usize,
     processing_already_ongoing: &'a AtomicBool,
@@ -185,7 +185,7 @@ pub fn microphone_thread(
                     let channels = config.channels();
                     let sample_rate = config.sample_rate();
 
-                    let mut twelve_seconds_buffer: Vec<f32> = vec![0.0f32; 16000 * MAX_BUFFER_SIZE];
+                    let mut twelve_seconds_buffer = Box::new([0.0f32; 16000 * MAX_BUFFER_SIZE]);
                     let mut number_unprocessed_samples: usize = 0; // Sample count for the interval of doing Shazam recognition (every 4 seconds)
                     let mut number_unmeasured_samples: usize = 0; // Sample count for doing volume measurement (every 24th of second)
 


### PR DESCRIPTION
This 32 MiB array seems way too big for what it seems to be used for though, `write_data()` takes only `buffer_size_secs` out of it, which should be no more than 12 (according to its name), so perhaps we should also change `MAX_BUFFER_SIZE` from 512 to just 12?  This would lower it to just 750 KiB.