### PR TITLE
Replace custom regex with simpler serde_json function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,7 +2498,6 @@ dependencies = [
  "pulsectl-rs",
  "rand",
  "realfft",
- "regex",
  "rodio",
  "rustfft",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ uuid = { version = "1.23.0", features = ["v4"] }
 glib = { version = "0.21", features = ["log", "v2_66"] }
 serde = { version = "1.0.115", features = ["derive"] }
 csv = "1.1.3"
-regex = "1.5.4"
 rand = "0.10.0"
 gettext-sys = { version = "0.26.0", features = ["gettext-system"] }
 gettext-rs = { version = "0.7.7" }

--- a/src/core/http_task.rs
+++ b/src/core/http_task.rs
@@ -1,6 +1,5 @@
 use gettextrs::gettext;
-use regex::Regex;
-use serde_json::{to_string_pretty, Value};
+use serde_json::Value;
 use soup::prelude::SessionExt;
 use std::error::Error;
 
@@ -82,15 +81,7 @@ async fn try_recognize_song(
             Value::String(string) => Some(string.to_string()),
             _ => None,
         },
-        shazam_json: Regex::new("\n *")
-            .unwrap()
-            .replace_all(
-                &Regex::new("([,:])\n *")
-                    .unwrap()
-                    .replace_all(&to_string_pretty(&json_object).unwrap(), "$1 "),
-                "",
-            )
-            .into_owned(),
+        shazam_json: serde_json::to_string(&json_object).unwrap(),
     })
 }
 


### PR DESCRIPTION
`serde_json::to_string_pretty()` adds a lot of whitespace which was then removed again using `regex`.

Replacing this all with `serde_json::to_string()` allows us to remove the `regex` dependency, and thus lower the stripped binary size from 11 MiB to 8.9 MiB!