### PR TITLE
Replace image with gdk-pixbuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2480,6 +2480,7 @@ dependencies = [
  "directories",
  "fern",
  "flate2",
+ "gdk-pixbuf",
  "gdk4",
  "gettext-rs",
  "gettext-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,11 @@ gdk = { version = "0.10.3", package = "gdk4", optional = true }
 gio = { version = "0.21.5", features = ["v2_74"], optional = true }
 percent-encoding = { version = "2.1.0", optional = true } # For percent-encoding contents in URLs
 chrono = { version = "0.4.13" } # For formatting dates
+gdk-pixbuf = { version = "0.21.5", optional = true }
 directories = {version = "6.0" }
 toml = "1.0.1"
 app_dirs = { version = "1.2.1" } # For obtaining and creating either the %APPDATA%, the dotfile path or similar
 soup3 = { version = "0.8.0", features = [ "v3_4" ] }
-image = { version = "0.25.9", default-features = false, features = ["png"] }
 
 [build-dependencies]
 gettext-sys = { version = "0.26.0", features = ["gettext-system"] }
@@ -61,7 +61,7 @@ glib-build-tools = "0.21.0"
 
 [features]
 default = ["gui", "ffmpeg", "pulse", "mpris", "pipewire" ]
-gui = ["gtk", "adw", "gdk", "gio", "percent-encoding", "ksni"]
+gui = ["gtk", "adw", "gdk", "gio", "percent-encoding", "ksni", "gdk-pixbuf"]
 pulse = [ "pulsectl-rs", "libpulse-binding" ]
 mpris = [ "mpris-server" ]
 pipewire = []

--- a/src/plugins/ksni.rs
+++ b/src/plugins/ksni.rs
@@ -1,6 +1,5 @@
 use crate::core::thread_messages::GUIMessage;
 use gettextrs::gettext;
-use image::GenericImageView;
 use ksni::TrayMethods;
 
 pub struct SystrayInterface {
@@ -15,19 +14,15 @@ impl ksni::Tray for SystrayInterface {
         "re.fossplant.songrec-symbolic".into()
     } */
     fn icon_pixmap(&self) -> Vec<ksni::Icon> {
-        let img = image::load_from_memory_with_format(
-            include_bytes!("../../packaging/rootfs/usr/share/icons/hicolor/32x32/apps/re.fossplant.songrec-symbolic.png"),
-            image::ImageFormat::Png,
-        ).unwrap();
-        let (width, height) = img.dimensions();
-        let mut data = img.into_rgba8().into_vec();
+        let img = gdk_pixbuf::Pixbuf::from_resource("re.fossplant.songrec-symbolic.png").unwrap();
+        let mut data = img.read_pixel_bytes().to_vec();
         assert_eq!(data.len() % 4, 0);
         for pixel in data.as_chunks_mut::<4>().0 {
             pixel.rotate_right(1) // rgba to argb
         }
         vec![ksni::Icon {
-            width: width as i32,
-            height: height as i32,
+            width: img.width(),
+            height: img.height(),
             data,
         }]
     }


### PR DESCRIPTION
This reverts commit 62aee2f533642874b90dca076fa6897aecb40c80.

On the other hand, this allows to remove 10 crates, and significantly reduce compilation time, while also removing 220 KiB from the stripped binary.

Note: this is untested, I don’t have any SNI setup.