### PR TITLE
Display Preferences shortcut in the F10 menu

### DIFF
--- a/src/gui/interface-autogenerated.ui
+++ b/src/gui/interface-autogenerated.ui
@@ -555,9 +555,8 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
         <attribute name="label" translatable="yes">Show notifications</attribute>
       </item>
       <item>
-        <attribute name="action">navigation.push</attribute>
+        <attribute name="action">win.show-preferences</attribute>
         <attribute name="label" translatable="yes">_Preferences...</attribute>
-        <attribute name="target">settings_tag</attribute>
       </item>
     </section>
     <section>

--- a/src/gui/interface.blp
+++ b/src/gui/interface.blp
@@ -482,9 +482,8 @@ menu main_menu_model {
     }
 
     item {
-      action: "navigation.push";
+      action: "win.show-preferences";
       label: _("_Preferences...");
-      target: "settings_tag";
     }
   }
 


### PR DESCRIPTION
By using the action for which we have an accelerator set, the menu will automatically display the shortcut on the side of the Preferences item.